### PR TITLE
ZSH - Replace exa with eza

### DIFF
--- a/system/aliases.sh
+++ b/system/aliases.sh
@@ -30,7 +30,7 @@ alias gst='git status'
 # | ls |
 # +----+
 
-alias ll='exa -alh --git --icons'
+alias ll='eza -alh --git --icons'
 
 # +------+
 # | nvim |


### PR DESCRIPTION
This is because exa got deprecated, and there's a fork which is [eza](https://github.com/eza-community/eza).