### PR TITLE
ZSH - Fix compinit duplication

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -15,8 +15,3 @@ source $DOTFILES/zsh/themes/.themes.zsh
 
 # Plugins - SHOULD BE AT THE END OF THIS FILE
 source $DOTFILES/zsh/plugins/.plugins.zsh
-# The following lines have been added by Docker Desktop to enable Docker CLI completions.
-fpath=(/Users/joao/.docker/completions $fpath)
-autoload -Uz compinit
-compinit
-# End of Docker CLI completions

--- a/zsh/options/completion.zsh
+++ b/zsh/options/completion.zsh
@@ -4,16 +4,20 @@ fpath=($DOTFILES/zsh/plugins/zsh-completions/src $fpath)
 # asdf
 fpath=(${ASDF_DATA_DIR:-$HOME/.asdf}/completions $fpath)
 
-# Homebrew autosuggestions
+# Homebrew
 if type brew &>/dev/null; then
   export FPATH="$(brew --prefix)/share/zsh/site-functions:$FPATH"
-
-  autoload -Uz compinit
-  compinit
 fi
+
+# Docker
+fpath=($HOME/.docker/completions $fpath)
 
 # FZF
 [[ $- == *i* ]] && source "/opt/homebrew/opt/fzf/shell/completion.zsh" 2> /dev/null
+
+# Initialize completions (must be after all fpath modifications)
+autoload -Uz compinit
+compinit
 
 # +---------+
 # | Options |


### PR DESCRIPTION
## Summary
- Move Docker CLI completions from `.zshrc` into `completion.zsh`
- Call `compinit` once after all `fpath` modifications instead of twice
- Improves shell startup time