### PR TITLE
ZSH - Add history options

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -7,6 +7,9 @@ source $DOTFILES/zsh/options/completion.zsh
 # Expansion and Globbing
 source $DOTFILES/zsh/options/expansion_globbing.zsh
 
+# History
+source $DOTFILES/zsh/options/history.zsh
+
 # Bindings
 source $DOTFILES/zsh/bindings.zsh
 

--- a/zsh/options/history.zsh
+++ b/zsh/options/history.zsh
@@ -1,0 +1,5 @@
+setopt HIST_IGNORE_ALL_DUPS  # Remove older duplicate entries from history
+setopt HIST_SAVE_NO_DUPS    # Don't write duplicate entries to history file
+setopt HIST_REDUCE_BLANKS   # Remove superfluous blanks from history items
+setopt SHARE_HISTORY        # Share history across all terminal sessions
+setopt INC_APPEND_HISTORY   # Write to history file immediately, not on shell exit


### PR DESCRIPTION
## Summary
- Deduplicate history entries
- Share history across all terminal sessions
- Write history immediately instead of on shell exit