### PR TITLE
ZSH - Add navigation and correction options

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -10,6 +10,9 @@ source $DOTFILES/zsh/options/expansion_globbing.zsh
 # History
 source $DOTFILES/zsh/options/history.zsh
 
+# Navigation
+source $DOTFILES/zsh/options/navigation.zsh
+
 # Bindings
 source $DOTFILES/zsh/bindings.zsh
 

--- a/zsh/options/navigation.zsh
+++ b/zsh/options/navigation.zsh
@@ -1,0 +1,4 @@
+setopt AUTO_CD              # Type directory name to cd into it
+setopt AUTO_PUSHD           # Push directory to stack on cd
+setopt PUSHD_IGNORE_DUPS    # Don't push duplicate directories
+setopt CORRECT              # Suggest corrections for mistyped commands


### PR DESCRIPTION
## Summary
- Auto-cd into directories by typing the name
- Push directories to stack for easy navigation with `popd`
- Suggest corrections for mistyped commands