### PR TITLE
ZSH - Migrate from z to zoxide

### DIFF
--- a/system/env.sh
+++ b/system/env.sh
@@ -50,10 +50,8 @@ export RUSTUP_HOME="$XDG_DATA_HOME/.rustup"
 # Wezterm
 export WEZTERM_CONFIG_FILE="$DOTFILES/wezterm/wezterm.lua"
 
-# Z
-export Z_DATA_FOLDER="$XDG_DATA_HOME/z"
-mkdir -p $Z_DATA_FOLDER
-export _Z_DATA="$Z_DATA_FOLDER/.z" # Datafile location
+# Zoxide
+export _ZO_DATA_DIR="$XDG_DATA_HOME/zoxide"
 
 # ERLANG
 

--- a/zsh/.zprofile
+++ b/zsh/.zprofile
@@ -5,9 +5,6 @@ eval "$(/opt/homebrew/bin/brew shellenv)"
 LDFLAGS="-L/opt/homebrew/opt/openssl@3/lib"
 CPPFLAGS="-I/opt/homebrew/opt/openssl@3/include"
 
-# Z
-. /opt/homebrew/etc/profile.d/z.sh
-
 # JAVA
 JAVA_HOME="$XDG_DATA_HOME/.asdf/plugins/java/set-java-home.zsh"
 if [ -f $JAVA_HOME ]; then

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -19,5 +19,8 @@ source $DOTFILES/zsh/bindings.zsh
 # Theme - SHOULD BE SOURCED BEFORE PLUGINS
 source $DOTFILES/zsh/themes/.themes.zsh
 
+# Zoxide
+eval "$(zoxide init zsh)"
+
 # Plugins - SHOULD BE AT THE END OF THIS FILE
 source $DOTFILES/zsh/plugins/.plugins.zsh


### PR DESCRIPTION
## Summary
- Replace rupa/z with zoxide for smarter, faster directory jumping
- Remove z config from `env.sh` and `.zprofile`
- Add zoxide init to `.zshrc`
- `z` command works the same, plus `zi` for interactive selection with fzf