### PR TITLE
Nvim - Prioritize git root for project detection

### DIFF
--- a/nvim/lua/config/options.lua
+++ b/nvim/lua/config/options.lua
@@ -4,3 +4,6 @@
 
 -- Biome: Enable this option to avoid conflicts with Prettier.
 vim.g.lazyvim_prettier_needs_config = true
+
+-- Use git root as project root
+vim.g.root_spec = { { ".git" }, "lsp", "cwd" }


### PR DESCRIPTION
## Summary
- Reorder `root_spec` to check for `.git` before LSP
- File explorer and pickers now open at the repository root