### PR TITLE
Tmux - Add vim-tmux-navigator with TPM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "zsh/themes/powerlevel10k"]
 	path = zsh/themes/powerlevel10k
 	url = https://github.com/romkatv/powerlevel10k.git
+[submodule "tmux/plugins/tpm"]
+	path = tmux/plugins/tpm
+	url = https://github.com/tmux-plugins/tpm

--- a/nvim/lua/plugins/tmux-navigator.lua
+++ b/nvim/lua/plugins/tmux-navigator.lua
@@ -1,0 +1,9 @@
+return {
+  "christoomey/vim-tmux-navigator",
+  keys = {
+    { "<C-h>", "<cmd>TmuxNavigateLeft<cr>" },
+    { "<C-j>", "<cmd>TmuxNavigateDown<cr>" },
+    { "<C-k>", "<cmd>TmuxNavigateUp<cr>" },
+    { "<C-l>", "<cmd>TmuxNavigateRight<cr>" },
+  },
+}

--- a/system/aliases.sh
+++ b/system/aliases.sh
@@ -54,5 +54,11 @@ alias ll='eza -alh --git --icons'
 # +------+
 
 alias nv='nvim'
+
+# +------+
+# | tmux |
+# +------+
+
+alias tmux='tmux -f "$TMUX_CONF"'
 alias vi='nvim'
 alias vim='nvim'

--- a/system/env.sh
+++ b/system/env.sh
@@ -7,6 +7,9 @@ export XDG_CACHE_HOME="$HOME/.cache"      # Where user-specific non-essential (c
 export XDG_DATA_HOME="$HOME/.local/share" # Where user-specific data files is written
 #export XDG_CONFIG_HOME="$HOME/.config"      # Where user-specific configurations are stored
 
+# Tmux
+export TMUX_CONF="$DOTFILES/tmux/tmux.conf"
+
 # +--------------------+
 # |                    |
 # | Add New Envs Above |

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,0 +1,29 @@
+# Terminal
+set -g default-terminal "tmux-256color"
+set -as terminal-features ",xterm-256color:RGB"
+set -s extended-keys on
+
+# Mouse
+set -g mouse on
+
+# Keys
+bind -n S-Enter send-keys Escape "[13;2u"
+
+# Windows & panes
+set -g base-index 1
+setw -g pane-base-index 1
+set -g renumber-windows on
+
+# Status bar
+set -g status-position top
+
+# +--------------------+
+# | Plugins            |
+# +--------------------+
+
+set-environment -g TMUX_PLUGIN_PATH "$HOME/.dotfiles/tmux/plugins"
+
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'christoomey/vim-tmux-navigator'
+
+run "$HOME/.dotfiles/tmux/plugins/tpm/tpm"


### PR DESCRIPTION
## Why:

Working with multiple tmux panes and Neovim splits requires seamless navigation. Without this, switching between panes requires different keybindings depending on whether you're in Neovim or tmux.

## This change addresses the need by:

- Adding TPM (Tmux Plugin Manager) as a git submodule for managing tmux plugins
- Installing `christoomey/vim-tmux-navigator` for unified `Ctrl-h/j/k/l` navigation across tmux panes and Neovim splits
- Adding the matching Neovim plugin config for LazyVim
- Setting up tmux QoL defaults (1-indexed windows/panes, true color, top status bar, mouse support)
- Adding `TMUX_CONF` env var and tmux alias so the config is picked up from the dotfiles directory