### PR TITLE
Tmux - Add sensible defaults, resurrect, and status bar

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -3,7 +3,6 @@ set-option -g prefix C-space
 # Terminal
 set -g default-terminal "tmux-256color"
 set -as terminal-features ",xterm-256color:RGB"
-set -s extended-keys on
 
 # Mouse
 set -g mouse on
@@ -38,6 +37,8 @@ bind-key "C" new-window -c "#{pane_current_path}"
 
 # Status bar
 set -g status-position top
+set -g status-left "[#{session_name}] "
+set -g status-right ""
 
 # +--------------------+
 # | Plugins            |
@@ -46,6 +47,8 @@ set -g status-position top
 set-environment -g TMUX_PLUGIN_PATH "$HOME/.dotfiles/tmux/plugins"
 
 set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'christoomey/vim-tmux-navigator'
+set -g @plugin 'tmux-plugins/tmux-resurrect'
 
 run "$HOME/.dotfiles/tmux/plugins/tpm/tpm"


### PR DESCRIPTION
## Why:

The tmux setup needs better defaults, session persistence, and a cleaner status bar that only shows windows from the current session.

## This change addresses the need by:

- Adding `tmux-sensible` plugin (escape-time, history, focus-events, etc.)
- Adding `tmux-resurrect` for session save/restore across restarts
- Configuring status bar to show only session name + windows (not all sessions)
- Removing `extended-keys` which broke Shift+key in some TUI apps