### PR TITLE
Git - Manage config via XDG and use gh as credential helper

### DIFF
--- a/git/config
+++ b/git/config
@@ -1,0 +1,19 @@
+[user]
+	name = joaop21
+	email = jpsilva9898@gmail.com
+
+[init]
+	defaultBranch = main
+
+[pull]
+	rebase = true
+
+[credential "https://github.com"]
+	helper =
+	helper = !/opt/homebrew/bin/gh auth git-credential
+
+[filter "lfs"]
+	clean = git-lfs clean -- %f
+	smudge = git-lfs smudge -- %f
+	process = git-lfs filter-process
+	required = true

--- a/git/ignore
+++ b/git/ignore
@@ -1,0 +1,1 @@
+**/.claude/settings.local.json


### PR DESCRIPTION
## Why:

Git Credential Manager (GCM Core) pops up browser/dialog windows for authentication, which is disruptive. Additionally, `~/.gitconfig` was not version-controlled in the dotfiles repo.

## This change addresses the need by:

- Adding `git/config` and `git/ignore` to the dotfiles repo, which git finds automatically via `XDG_CONFIG_HOME`
- Replacing GCM with `gh` CLI as the credential helper for GitHub, which authenticates silently via the existing `gh auth` session
- Removing the Azure DevOps credential config (unused)