### PR TITLE
Claude - Untrack settings.local.json

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(find .:*)",
-      "Bash(ls:*)",
-      "WebFetch(domain:docs.anthropic.com)"
-    ]
-  }
-}


### PR DESCRIPTION
## Why:

`.claude/settings.local.json` is per-machine local state (Claude Code's project-local permission allowlist) and shouldn't live on remote main.

## This change addresses the need by:

- Untracking the file via `git rm --cached` (the local copy is preserved at commit time).
- The global gitignore at `git/ignore` already has `**/.claude/settings.local.json`, so future versions stay ignored.

## Heads up before pulling

After this merges, pulling main onto a working tree that still has the file will cause git to delete the local copy as part of the merge (gitignore doesn't shield tracked-then-deleted paths). Back up the content first if you want to keep it.

Last-known content (snapshot at PR creation):

```json
{
  "permissions": {
    "allow": [
      "Bash(find .:*)",
      "Bash(ls:*)",
      "WebFetch(domain:docs.anthropic.com)"
    ]
  }
}
```