### PR TITLE
Claude - Add statusline

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -110,5 +110,9 @@
   "skipAutoPermissionPrompt": true,
   "permissions": {
     "defaultMode": "auto"
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "bash ~/.dotfiles/claude/statusline.sh"
   }
 }

--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+input=$(cat)
+
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // ""')
+model=$(echo "$input" | jq -r '.model.display_name // ""')
+used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+
+# Directory: basename of cwd
+dir=$(basename "$cwd")
+
+# Git branch from cwd (skip lock to avoid contention)
+branch=""
+if git --no-optional-locks -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  branch=$(git --no-optional-locks -C "$cwd" branch --show-current 2>/dev/null)
+fi
+
+# Build parts
+parts=()
+
+# dir segment (cyan)
+[ -n "$dir" ] && parts+=("$(printf '\033[36m%s\033[0m' "$dir")")
+
+# git branch segment (magenta)
+[ -n "$branch" ] && parts+=("$(printf '\033[35m%s\033[0m' "$branch")")
+
+# model segment (dim white)
+[ -n "$model" ] && parts+=("$(printf '\033[2m%s\033[0m' "$model")")
+
+# context usage segment (yellow when > 0)
+if [ -n "$used" ]; then
+  used_int=$(printf '%.0f' "$used")
+  parts+=("$(printf '\033[33mctx:%s%%\033[0m' "$used_int")")
+fi
+
+# Join with separator
+result=""
+for part in "${parts[@]}"; do
+  if [ -z "$result" ]; then
+    result="$part"
+  else
+    result="$result $(printf '\033[2m|\033[0m') $part"
+  fi
+done
+
+printf '%s' "$result"


### PR DESCRIPTION
## Why:

Claude Code status line was unconfigured. Wanted it to mirror the Powerlevel10k shell prompt for visual consistency across terminal and Claude Code.

## This change addresses the need by:

- Adding `claude/statusline.sh` that renders: directory basename (cyan), git branch (magenta), model name (dim), context usage % (yellow)
- Using `git --no-optional-locks` to avoid lock contention while reading repo state
- Wiring it into `claude/settings.json` via the `statusLine` command hook