### PR TITLE
Tmux - Enable focus events

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -7,6 +7,9 @@ set -as terminal-features ",xterm-256color:RGB"
 # Mouse
 set -g mouse on
 
+# Focus events (lets editors/plugins track terminal focus)
+set -g focus-events on
+
 # Keys
 bind -n S-Enter send-keys Escape "[13;2u"
 bind C-l send-keys 'C-l'


### PR DESCRIPTION
## Why:
tmux `focus-events` was off, so editors and plugins (e.g. vim-tmux-navigator) couldn't track terminal focus changes inside tmux.

## This change addresses the need by:
Enabling `set -g focus-events on` in `tmux/tmux.conf`.