### PR TITLE
Claude - Show tokens in statusline

### DIFF
--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -5,6 +5,21 @@ input=$(cat)
 cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // ""')
 model=$(echo "$input" | jq -r '.model.display_name // ""')
 used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+tok_used=$(echo "$input" | jq -r '.context_window.total_input_tokens // empty')
+tok_max=$(echo "$input" | jq -r '.context_window.context_window_size // empty')
+
+# Format a token count compactly: 820 -> 820, 45234 -> 45.2k, 1000000 -> 1M.
+# Whole values drop the decimal (177000 -> 177k). Mode "round" always does.
+fmt_tokens() {
+  awk -v n="$1" -v mode="$2" 'BEGIN {
+    if (n >= 1000000)   { div=1000000; suf="M" }
+    else if (n >= 1000) { div=1000;    suf="k" }
+    else                { printf "%d", n; exit }
+    v = n/div
+    if (mode == "round" || v == int(v)) printf "%g%s", v, suf
+    else                                printf "%.1f%s", v, suf
+  }'
+}
 
 # Directory: basename of cwd
 dir=$(basename "$cwd")
@@ -27,10 +42,15 @@ parts=()
 # model segment (dim white)
 [ -n "$model" ] && parts+=("$(printf '\033[2m%s\033[0m' "$model")")
 
-# context usage segment (yellow when > 0)
+# context usage segment: tokens + percentage (yellow)
 if [ -n "$used" ]; then
   used_int=$(printf '%.0f' "$used")
-  parts+=("$(printf '\033[33mctx:%s%%\033[0m' "$used_int")")
+  if [ -n "$tok_used" ] && [ -n "$tok_max" ]; then
+    seg=$(printf 'ctx:%s/%s (%s%%)' "$(fmt_tokens "$tok_used")" "$(fmt_tokens "$tok_max" round)" "$used_int")
+  else
+    seg=$(printf 'ctx:%s%%' "$used_int")
+  fi
+  parts+=("$(printf '\033[33m%s\033[0m' "$seg")")
 fi
 
 # Join with separator


### PR DESCRIPTION
## Why:
The statusline only showed context usage as a percentage (`ctx:NN%`). The raw token count is more actionable for knowing how much room is left in the context window.

## This change addresses the need by:
Reading `.context_window.total_input_tokens` and `.context_window.context_window_size` from the statusLine payload and rendering them next to the percentage, e.g. `ctx:45.2k/1M (23%)`. A `fmt_tokens` helper formats counts compactly (`820`, `45.2k`, `1M`) and drops trailing zeros on round caps. Falls back to the original `ctx:NN%` when token fields are absent (before the first API call or right after `/compact`).