### PR TITLE
Claude - Show effort level in statusline

### DIFF
--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -4,6 +4,7 @@ input=$(cat)
 
 cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // ""')
 model=$(echo "$input" | jq -r '.model.display_name // ""')
+effort=$(echo "$input" | jq -r '.effort.level // empty')
 used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
 
 # Directory: basename of cwd
@@ -24,8 +25,12 @@ parts=()
 # git branch segment (magenta)
 [ -n "$branch" ] && parts+=("$(printf '\033[35m%s\033[0m' "$branch")")
 
-# model segment (dim white)
-[ -n "$model" ] && parts+=("$(printf '\033[2m%s\033[0m' "$model")")
+# model segment (dim white), with effort level when present
+if [ -n "$model" ]; then
+  label="$model"
+  [ -n "$effort" ] && label="$model ($effort)"
+  parts+=("$(printf '\033[2m%s\033[0m' "$label")")
+fi
 
 # context usage segment (yellow when > 0)
 if [ -n "$used" ]; then


### PR DESCRIPTION
## Why:
The statusline showed the model name but not the current reasoning effort level, so there was no at-a-glance way to tell whether the session is running at low/medium/high/etc effort.

## This change addresses the need by:
Reading `.effort.level` from the statusLine payload and appending it to the model segment, e.g. `Opus 4.8 (high)`. The field is absent for models that don't support effort, so the segment falls back to just the model name in that case.