### PR TITLE
Tmux - Track vim-tmux-navigator as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "tmux/plugins/tpm"]
 	path = tmux/plugins/tpm
 	url = https://github.com/tmux-plugins/tpm
+[submodule "tmux/plugins/vim-tmux-navigator"]
+	path = tmux/plugins/vim-tmux-navigator
+	url = https://github.com/christoomey/vim-tmux-navigator


### PR DESCRIPTION
## Why:

`vim-tmux-navigator` was installed by TPM at runtime and sat untracked in the repo. Every other plugin (`tpm`, all `zsh/plugins/*`) is pinned as a git submodule, so this one was the odd one out — no pinned revision, shows up as untracked noise.

## This change addresses the need by:

Adding `christoomey/vim-tmux-navigator` as a git submodule at `tmux/plugins/vim-tmux-navigator`, matching the existing `tpm` convention.