### PR TITLE
Gitignore - Ignore generated Homebrew and SwiftPM state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,12 @@ github-copilot
 # GPG
 gnupg
 
+# Homebrew
+homebrew/trust.json
+
+# SwiftPM
+swiftpm
+
 # UV
 uv/uv-receipt.json
 


### PR DESCRIPTION
## Why:
Because `XDG_CONFIG_HOME` points at the dotfiles repo, Homebrew and SwiftPM write their generated state here (`homebrew/trust.json`, `swiftpm/cache`, `swiftpm/security`, `swiftpm/configuration`). These are machine-specific, regenerated, and potentially sensitive — they show up as untracked noise and should never be committed, just like the already-ignored `gnupg`, `github-copilot`, and `.expert` dirs.

## This change addresses the need by:
Adding `homebrew/trust.json` and `swiftpm` to `.gitignore`. `homebrew/` itself is left trackable so a future intentional file (e.g. a `Brewfile`) can still be committed, mirroring how only `uv/uv-receipt.json` is ignored under `uv/`.