### PR TITLE
ZSH - Fix autoload after zsh upgrade (stop exporting FPATH)

### DIFF
--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -2,6 +2,16 @@
 source $HOME/.dotfiles/system/env.sh
 source $HOME/.dotfiles/system/secret.env.sh
 
+# Keep zsh's standard autoload functions reachable, and never export FPATH.
+# zsh ties FPATH (env scalar) <-> fpath (array). An exported FPATH carries a
+# version-pinned functions dir (.../Cellar/zsh/<ver>/...) that goes stale on
+# `brew upgrade zsh`; inherited by a long-lived child (e.g. a tmux pane that
+# outlived the upgrade) it shadows the new dir and breaks autoload —
+# add-zsh-hook, compinit, is-at-least all fail with "function definition file
+# not found". Anchor the version-independent functions dir, then de-export.
+[[ -d /opt/homebrew/share/zsh/functions ]] && fpath=(/opt/homebrew/share/zsh/functions $fpath)
+typeset +x FPATH
+
 # Zsh Environment variables
 export ZDOTDIR="$XDG_CONFIG_HOME/zsh"
 export HISTFILE="$XDG_CACHE_HOME/zsh/.zhistory"    	# History filepath

--- a/zsh/options/completion.zsh
+++ b/zsh/options/completion.zsh
@@ -4,9 +4,9 @@ fpath=($DOTFILES/zsh/plugins/zsh-completions/src $fpath)
 # asdf
 fpath=(${ASDF_DATA_DIR:-$HOME/.asdf}/completions $fpath)
 
-# Homebrew
+# Homebrew (plain fpath=(), never `export FPATH` — see .zshenv for why)
 if type brew &>/dev/null; then
-  export FPATH="$(brew --prefix)/share/zsh/site-functions:$FPATH"
+  fpath=($(brew --prefix)/share/zsh/site-functions $fpath)
 fi
 
 # Docker


### PR DESCRIPTION
## Why:
After `brew upgrade zsh` (5.9 → 5.9.1), new shells printed `function definition file not found` for `add-zsh-hook`, `compinit`, and `is-at-least`, plus a bogus Powerlevel10k minimum-version warning.

Root cause: `completion.zsh` ran `export FPATH=...`. zsh ties `FPATH` (env scalar) ↔ `fpath` (array), so exporting baked the version-pinned functions dir (`.../Cellar/zsh/5.9/share/zsh/functions`) into the environment. The upgrade deleted that keg, and a long-lived parent (the tmux server started before the upgrade) kept injecting the now-dead path into every new shell. An inherited `FPATH` replaces zsh's compiled-in default, so the standard autoload functions could no longer be found.

## This change addresses the need by:
- Changing the Homebrew block in `completion.zsh` to a plain `fpath=(...)` assignment instead of `export FPATH` — never leaking a version-pinned path into the environment again.
- In `.zshenv` (which runs before `.zprofile`, where asdf's java hook is the first autoload consumer): anchoring the version-independent `/opt/homebrew/share/zsh/functions` dir into `fpath` and de-exporting `FPATH` (`typeset +x FPATH`). This breaks the propagation chain so children never inherit a stale path, and any inherited stale `FPATH` self-heals — no `tmux kill-server` or reboot needed.

Verified: clean shell and stale-inherited-`FPATH` (tmux-pane) scenarios both start with zero errors; `FPATH` is no longer exported; `is-at-least` resolves.
