### PR TITLE
Claude - Sync captured runtime settings

### DIFF
--- a/claude/settings.base.json
+++ b/claude/settings.base.json
@@ -21,6 +21,7 @@
       }
     },
     "subvisual": {
+      "autoUpdate": true,
       "source": {
         "repo": "subvisual/harness",
         "source": "github"
@@ -134,6 +135,7 @@
     "defaultMode": "auto"
   },
   "skipAutoPermissionPrompt": true,
+  "skipWorkflowUsageWarning": true,
   "statusLine": {
     "command": "bash ~/.dotfiles/claude/statusline.sh",
     "type": "command"


### PR DESCRIPTION
## Why:

Claude Code rewrites `~/.claude/settings.json` at runtime. `capture-settings.sh` snapshots the live file into `settings.base.json` at SessionEnd, leaving a working-tree change to commit manually.

## This change addresses the need by:

Committing two runtime additions captured into `settings.base.json`:
- `subvisual.autoUpdate: true` — plugin marketplace auto-update
- `skipWorkflowUsageWarning: true`