### PR TITLE
AoE - Track config.toml, ignore runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ uv/uv-receipt.json
 
 # Android
 .android
+
+# Agent of Empires (aoe) — track config.toml, ignore generated runtime state
+agent-of-empires/*
+!agent-of-empires/config.toml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ Personal dotfiles repository using XDG Base Directory Specification. `XDG_CONFIG
 - `zed/` — Zed editor config
 - `bat/`, `ripgrep/` — CLI tool configs (referenced via env vars)
 - `gh/` — GitHub CLI config and aliases
+- `agent-of-empires/` — aoe (tmux AI-agent session manager) XDG config; only `config.toml` is tracked, generated runtime state (logs, caches, locks, `profiles/`, `tui-presence/`, `trusted_repos.toml`) is gitignored
 
 ## Encryption
 

--- a/agent-of-empires/config.toml
+++ b/agent-of-empires/config.toml
@@ -1,0 +1,138 @@
+default_profile = ""
+
+[theme]
+name = "zinc"
+color_mode = "truecolor"
+idle_decay_minutes = 0
+
+[updates]
+update_check_mode = "notify"
+check_interval_hours = 24
+notify_in_cli = true
+web_poll_interval_minutes = 60
+
+[telemetry]
+enabled = false
+
+[worktree]
+enabled = false
+path_template = "../{repo-name}-worktrees/{branch}"
+bare_repo_path_template = "./{branch}"
+auto_cleanup = true
+show_branch_in_tui = true
+delete_branch_on_cleanup = false
+workspace_path_template = "../{branch}-workspace-{session-id}"
+init_submodules = true
+
+[sandbox]
+enabled_by_default = false
+default_image = "ghcr.io/agent-of-empires/aoe-sandbox:latest"
+extra_volumes = []
+environment = [
+    "TERM",
+    "COLORTERM",
+    "FORCE_COLOR",
+    "NO_COLOR",
+]
+auto_cleanup = true
+default_terminal_mode = "host"
+volume_ignores = []
+volume_ignores_strategy = "anonymous"
+mount_ssh = false
+selinux_relabel = false
+container_runtime = "docker"
+
+[tmux]
+status_bar = "auto"
+mouse = "auto"
+clipboard = "auto"
+
+[session]
+yolo_mode_default = false
+agent_status_hooks = true
+smart_rename = true
+mouse_capture = true
+strict_hotkeys = false
+snooze_duration_minutes = 30
+auto_stop_idle_secs = 0
+restart_wake_message = "wake up: pick up what you were doing"
+row_tag = "none"
+session_id_poller_max_threads = 50
+live_send_exit_chord = "C-q"
+live_send_leader = "C-b"
+new_session_attach_mode = "live_send"
+default_attach_mode = "live_send"
+click_action = "live_send"
+confirm_before_quit = true
+tie_workdir_to_name = true
+
+[diff]
+context_lines = 3
+split_view = false
+
+[hooks]
+
+[host_hooks]
+
+[sound]
+enabled = false
+mode = "random"
+
+[status_hooks]
+enabled = false
+debounce_ms = 100
+
+[app_state]
+has_seen_welcome = true
+has_seen_web_tour = true
+last_seen_version = "1.11.1"
+show_preview_info = false
+has_responded_to_telemetry = true
+has_seen_custom_instruction_warning = false
+has_seen_non_git_project_warning = false
+has_acknowledged_agent_hooks = true
+has_acknowledged_volume_ignores_globs = false
+sort_order = "oldest"
+group_by = "project"
+
+[app_state.web_ui_state]
+aoe-web-settings = '{"mobileFontSize":8,"desktopFontSize":14,"autoOpenKeyboard":true,"persistentTerminals":false,"maxPersistentTerminals":5,"diffViewMode":"tree","diffViewLayout":"unified","collapsedDiffDirs":[]}'
+aoe-welcome-seen = "1"
+
+[web]
+notifications_enabled = true
+notify_on_waiting = true
+notify_on_idle = false
+notify_on_error = true
+notify_on_wake_fire = true
+
+[auth]
+persist_sessions = true
+
+[acp]
+default_agent = "aoe-agent"
+max_concurrent_workers = 5
+replay_events = 0
+replay_bytes = 5242880
+node_path = ""
+show_tool_durations = true
+queue_drain_mode = "combined"
+max_concurrent_resumes = 4
+force_end_turn_threshold_secs = 30
+silent_orphan_grace_secs = 120
+silent_orphan_fast_grace_secs = 20
+auto_stop_idle_secs = 0
+rate_limit_auto_resume = false
+rate_limit_auto_resume_grace_secs = 15
+allow_agent_install = false
+
+[logging]
+default_level = "info"
+output = "file"
+file_path = "debug.log"
+rotation = "size"
+max_size_mib = 50
+keep_count = 5
+show_spans = false
+
+[logging.targets]

--- a/claude/settings.base.json
+++ b/claude/settings.base.json
@@ -29,6 +29,16 @@
     }
   },
   "hooks": {
+    "ElicitationResult": [
+      {
+        "hooks": [
+          {
+            "command": "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; case \"$AOE_INSTANCE_ID\" in *[!0-9a-zA-Z_-]*) exit 0 ;; esac; mkdir -p \"/tmp/aoe-hooks/$AOE_INSTANCE_ID\" 2>/dev/null; printf running > \"/tmp/aoe-hooks/$AOE_INSTANCE_ID/status\" 2>/dev/null; exit 0'",
+            "type": "command"
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "hooks": [
@@ -57,6 +67,16 @@
         "hooks": [
           {
             "command": "agent-deck hook-handler",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; case \"$AOE_INSTANCE_ID\" in *[!0-9a-zA-Z_-]*) exit 0 ;; esac; mkdir -p \"/tmp/aoe-hooks/$AOE_INSTANCE_ID\" 2>/dev/null; printf running > \"/tmp/aoe-hooks/$AOE_INSTANCE_ID/status\" 2>/dev/null; exit 0'",
             "type": "command"
           }
         ]


### PR DESCRIPTION
## Why:

Agent of Empires (aoe) uses `~/.dotfiles/agent-of-empires` as its XDG config home, so it dumps both real config and generated runtime state straight into the repo. The whole directory was showing as untracked, mixing the one file worth version-controlling (`config.toml`) with logs, caches, locks, live session state, and machine-specific trusted-repo paths. Separately, aoe's `agent_status_hooks` injected two Claude Code hooks into the live settings, captured into `settings.base.json` by the SessionEnd sync.

## This change addresses the need by:

- Tracking `agent-of-empires/config.toml` (theme, session, attach modes, telemetry, hooks).
- Adding a whitelist gitignore block: `agent-of-empires/*` with `!agent-of-empires/config.toml`, so any new generated file aoe writes is ignored automatically — `debug.log`, `update_cache.json`, `.recovery.lock`/`.telemetry.lock`, `.schema_version`, `profiles/`, `tui-presence/`, `trusted_repos.toml`.
- Documenting the directory and its track/ignore split in `CLAUDE.md`.
- Capturing aoe's two status hooks (`ElicitationResult`, `PreToolUse`) into `settings.base.json` — they write a `running` marker to `/tmp/aoe-hooks/$AOE_INSTANCE_ID/status` so aoe's dashboard can show this session's live state.